### PR TITLE
Update python-pip-openbsd-install.sh

### DIFF
--- a/openbsd/python-pip-openbsd-install.sh
+++ b/openbsd/python-pip-openbsd-install.sh
@@ -3,7 +3,7 @@
 # install python pip
 #===================
 
-sudo pkg_add -i py-pip
+doas pkg_add -i py-pip
 
 
 # create symlik for pip


### PR DESCRIPTION
sudo(8) was removed in OpenBSD 5.8. It was replaced by doas(1)