### PR TITLE
Add command to create missing "images" directory

### DIFF
--- a/libvirt/mac-kvm/mac-kvm.org
+++ b/libvirt/mac-kvm/mac-kvm.org
@@ -124,7 +124,7 @@ qemu-img create -f qcow2 mac_hdd_ng.img 128G
 move the mac_hdd_ng.img file to libvirt images
 
 #+begin_src sh
-mv mac_hdd_ng.img ~/libvirt/images
+mkdir -p ~/libvirt/images && mv mac_hdd_ng.img ~/libvirt/images
 #+end_src
 
 *** edit the ~/libvirt/OSX-KVM/OpenCore-Boot.sh


### PR DESCRIPTION
The "images" directory does not exist inside the "~/libvirt/" directory, so the command  "mv mac_hdd_ng.img ~/libvirt/images" results in moving the file into "~/libvirt/" and renaming the file "mac_hdd_ng.img" "images".  

I suspect that is not the intention. So creating the "images" directory prior to the move will have the intended result of moving the "mac_hdd_ng.img" file into the directory "images" in the "libvirt" parent directory.