### PR TITLE
Added command to create missing "~/libvirt" directory

### DIFF
--- a/libvirt/mac-kvm/mac-kvm.org
+++ b/libvirt/mac-kvm/mac-kvm.org
@@ -110,7 +110,7 @@ git clone --depth 1 --recursive https://github.com/kholia/OSX-KVM.git
 move the OSX-KVM git repo to ~/libvirt
 
 #+begin_src sh
-mv OSX-KVM ~/libvirt
+mkdir -p ~/libvirt/OSX-KVM && mv OSX-KVM ~/libvirt
 #+end_src
 
 *** Create a virtual HDD image where macOS will be installed.


### PR DESCRIPTION
The move command "mv OSX-KVM ~/libvirt" has unintended results if the "~/libvirt" directory does not exist. "OSX-KVM" is moved to $HOME and renamed "libvirt" instead of moving the directory into "libvirt"

Adding a command to create the directory prior to the move, ensure desired results.